### PR TITLE
release 0.2.0: automatically combine if coverage fails to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
-## 0.0.0
+## 0.2.0
+
+- automatically combine coverage if coverage fails to load.
+  - more info in the [docs](https://coverage.readthedocs.io/en/coverage-5.5/cmd.html#combining-data-files-coverage-combine)
+- give a better log message when coverage fails to load.
+
+## 0.1.0
 
 init

--- a/coverage_rich/__about__.py
+++ b/coverage_rich/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Waylon S. Walker <waylon@waylonwalker.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.0"
+__version__ = "0.2.0.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "pytest-mock",
-  "pytest-rich",
   "ruff",
   "black",
 ]
@@ -91,7 +90,6 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
-# addopts = "-ra -q --rich"
 addopts = "-ra -q"
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,8 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-ra -q --rich"
+# addopts = "-ra -q --rich"
+addopts = "-ra -q"
 asyncio_mode = "auto"
 testpaths = ["tests"]
 


### PR DESCRIPTION
- automatically try run `coverage combine` if it fails to load.
- give some log messages if it fails again.
